### PR TITLE
[Bugfix] Allow `User-agent` to be null

### DIFF
--- a/gke_logging/asgi.py
+++ b/gke_logging/asgi.py
@@ -28,7 +28,7 @@ def build_http_request_from_scope(scope: Scope) -> HttpRequest:
         url=str(req.url),
         # TODO: Confirm if this is accurate even for body-less requests
         request_size=req.headers.get("Content-Length"),
-        user_agent=req.headers["User-Agent"],
+        user_agent=req.headers.get("User-Agent"),
         remote_ip=req.client.host,
         server_ip=server_ip,
         referer=req.headers.get("Referer"),

--- a/gke_logging/asgi.py
+++ b/gke_logging/asgi.py
@@ -112,7 +112,7 @@ class GKELoggingMiddleware:
             referer=http_request.referer,
             user_agent=http_request.user_agent,
         )
-        data = {k: v or "-" for k, v in data.items()}
+        data = {k: v if v is not None else "-" for k, v in data.items()}
         log_line = self._access_log_message_format.format(**data)
 
         # Log levels should reflect status code

--- a/gke_logging/types.py
+++ b/gke_logging/types.py
@@ -61,7 +61,7 @@ class HttpRequest(BaseModel):
     method: HttpMethod = Field(alias="requestMethod")
     url: AnyHttpUrl = Field(alias="requestUrl")
     request_size: typing.Optional[str] = Field(None, alias="requestSize")
-    user_agent: str = Field(alias="userAgent")
+    user_agent: typing.Optional[str] = Field(None, alias="userAgent")
     remote_ip: str = Field(alias="remoteIp")
     server_ip: str = Field(alias="serverIp")
     referer: typing.Optional[str] = None


### PR DESCRIPTION
This preserves the best-effort nature of the GKE logging plumbing and prevents certain scenarios from causing post-request failures for ASGI applications.